### PR TITLE
Update Ehcache version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,33 +135,14 @@
             </dependency>
             <dependency>
                 <groupId>net.sf.ehcache</groupId>
-                <artifactId>ehcache-core</artifactId>
-                <version>1.7.2</version>
+                <artifactId>ehcache</artifactId>
+                <version>2.10.1</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>
                 <artifactId>jetty-utils</artifactId>
                 <version>${jetty-utils.version}</version>
             </dependency>
-
-            <!-- Get jetty from jetty-utils -->
-            <!--
-            <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-sslengine</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-java5-threadpool</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>


### PR DESCRIPTION
Update Ehcache version from 1.7.2 to 2.10.1.
With this update the artifact-id changes, too.

This changes impact on _argus-pep-server_ project.
